### PR TITLE
Fix api connection with postgres in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
+RUN npx prisma db push
 RUN npx prisma generate
 EXPOSE 3000
 CMD [ "npm", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,15 +8,12 @@ services:
     ports:
       - 3000:3000
     environment:
-      POSTGRES_HOST: postgresql://postgres:007934561cgtfru@localhost:5432/bank?schema=public
+      DATABASE_URL: postgresql://postgres:007934561cgtfru@postgres:5432/bank
       PORT: 3000
-
     depends_on:
-      - db
-    links:
-      - db
+      - postgres
 
-  db:
+  postgres:
     image: postgres
     restart: always
     environment:
@@ -25,4 +22,3 @@ services:
       POSTGRES_DB: bank
     ports:
     - "5432:5432"
-    


### PR DESCRIPTION
When you are using docker-compose, the service name will also be the host in your database connection string.

Example:
postgresql://postgres:<password>@<host>:<port>/<db_name>

The <host> must be the name of your service in docker-compose.